### PR TITLE
Add AOHP: OS-level agent harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Agent harnesses are end-user or developer-facing products that package model acc
 | [Hermes](https://github.com/nousresearch/hermes-agent) | 2026-02 | Nous Research | Yes |
 | [Warp](https://github.com/warpdotdev/warp) | 2026-04 | Warp | Yes |
 | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | 2026-05 | esengine | Yes |
+| [AOHP](https://github.com/aohp-os/aohp) | 2026-06 | aohp-os | Yes |
 
 
 `Yes*` indicates a partially open-source, open-core, or otherwise limited open-source model.


### PR DESCRIPTION
## Summary
- Add AOHP (https://github.com/aohp-os/aohp) to the Agent Harness table.
- Positioning: an OS-level agent harness project that provides more efficient service entry points for agent execution and improves the security of the harness system.

Paper: https://arxiv.org/abs/2606.23449

cc @mahonzhan

Made with [Cursor](https://cursor.com)