### PR TITLE
docs: add LWC project memory harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Agent harnesses are end-user or developer-facing products that package model acc
 | [Hermes](https://github.com/nousresearch/hermes-agent) | 2026-02 | Nous Research | Yes |
 | [Warp](https://github.com/warpdotdev/warp) | 2026-04 | Warp | Yes |
 | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | 2026-05 | esengine | Yes |
+| [LWC (Local Wiki CLI)](https://github.com/JanYork/llm-wiki-cli) | 2026-07 | JanYork | Yes |
 
 
 `Yes*` indicates a partially open-source, open-core, or otherwise limited open-source model.


### PR DESCRIPTION
Adds [LWC (Local Wiki CLI)](https://github.com/JanYork/llm-wiki-cli) to the Agent Harness timeline.

LWC is a developer-facing memory and context-delivery layer for coding agents: it persists source-grounded project knowledge, tracks citations/provenance, exposes bounded read-only retrieval over MCP, and optionally maintains document and code knowledge graphs. This fits the repository definition that harness products package memory and tooling into a usable developer experience.

- First public release: July 2026 (`v0.1.0`, published 2026-07-29)
- Developer: JanYork
- Open source: yes, Apache-2.0
- Validation: `git diff --check`