### PR TITLE
Add SandBase Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Agent harnesses are end-user or developer-facing products that package model acc
 | [Hermes](https://github.com/nousresearch/hermes-agent) | 2026-02 | Nous Research | Yes |
 | [Warp](https://github.com/warpdotdev/warp) | 2026-04 | Warp | Yes |
 | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | 2026-05 | esengine | Yes |
+| [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) | 2026-08 | SandBase | Yes |
 
 
 `Yes*` indicates a partially open-source, open-core, or otherwise limited open-source model.


### PR DESCRIPTION
## Summary

Add SandBase Harness to the Agent Harness table in chronological order.

SandBase Harness is an Apache-2.0 open-source harness for durable, isolated AI coding sessions, with command execution, file operations, snapshots, audit logs, and an active MCP Registry distribution.

Verification:
- Repository: https://github.com/sandbaseai/sandbase-harness
- Releases: https://github.com/sandbaseai/sandbase-harness/releases
- Official MCP Registry: https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.sandbaseai%2Fsandbase-harness

Disclosure: I am contributing this listing on behalf of the SandBase project.