### PR TITLE
Add UHP (Unified Harness Protocol) to Protocol section

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Protocols, conventions, and interface patterns worth watching in the agent ecosy
 | [A2UI](https://a2ui.org/) | Google with contributions from CopilotKit and the open-source community | 2025-09 | Agent-generated, declarative UI rendered natively across clients |
 | [Agent Skills](https://agentskills.io/) | Anthropic | 2025-10 | Portable skills and reusable capability packs for agents |
 | [DESIGN.md](https://stitch.withgoogle.com/docs/design-md/overview)	|Google (via Google Stitch)	| 2026-03	| Agent-readable design system rules (colors, typography, spacing, patterns) to enforce visual consistency in AI-generated UI |
+| [UHP](https://unifiedharnessprotocol.org/) | HarnessRouter | 2026-08 | An open standard for the application-to-harness boundary: one contract for applications to invoke, observe, and control agent harnesses (tasks, sessions, streaming, files, cancellation, results) 
 
 
 ## Roadmap 🗺️


### PR DESCRIPTION
Adds the Unified Harness Protocol (UHP) to the Protocol section, following the section's own framing: MCP connects agents to tools; ACP connects agents to editors; UHP connects applications to harnesses.

UHP is an open standard with a versioned specification (2026-08-11), an Apache-2.0 reference implementation, and a conformance suite. It evolves through a maintainer-led, proposal-first UEP (UHP Enhancement Proposal) process within the HarnessRouter repository; UHP is initiated and led by HarnessRouter and is moving toward neutral governance. Beyond the reference implementation it has independent, verified client implementations (SuperQode by Superagentic AI, AIWG, mini-ork), tracked by an independent adoption tracker.

- Spec/docs: https://unifiedharnessprotocol.org/
- Reference implementation (Apache-2.0): https://github.com/HarnessRouter/harnessrouter
- Independent adoption tracker: https://unifiedharnessprotocol.dev/adoption/