### PR TITLE
Add SandBase CLI to the agent harness catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Agent harnesses are end-user or developer-facing products that package model acc
 | [Hermes](https://github.com/nousresearch/hermes-agent) | 2026-02 | Nous Research | Yes |
 | [Warp](https://github.com/warpdotdev/warp) | 2026-04 | Warp | Yes |
 | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | 2026-05 | esengine | Yes |
+| [SandBase CLI](https://github.com/sandbaseai/cli) | 2026-06 | SandBase AI | Yes |
 
 
 `Yes*` indicates a partially open-source, open-core, or otherwise limited open-source model.


### PR DESCRIPTION
## Summary
- add SandBase CLI to the Agent Harness table
- record the canonical repository, organization, release month, and open-source status

## Why it fits
SandBase CLI is a terminal-native harness that packages model access, provider routing, MCP tool execution, OAuth, and rollback behind one Responses-compatible interface. It is a developer-facing product that demonstrates the scaffolding around models, matching this list's Agent Harness scope.

The entry is submitted from the `sandbaseai` organization and links to the canonical Apache-2.0 repository. Please verify details and adjust the release date or placement if needed.
