### PR TITLE
Add DeepSeek Harness to the agent harness directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Agent harnesses are end-user or developer-facing products that package model acc
 | [Hermes](https://github.com/nousresearch/hermes-agent) | 2026-02 | Nous Research | Yes |
 | [Warp](https://github.com/warpdotdev/warp) | 2026-04 | Warp | Yes |
 | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | 2026-05 | esengine | Yes |
+| [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) | 2026-08 | DeepSeek AI | Yes |
 
 
 `Yes*` indicates a partially open-source, open-core, or otherwise limited open-source model.


### PR DESCRIPTION
## Summary
- add the official DeepSeek Harness runtime to the Agent Harness table
- link directly to the upstream repository for verification

DeepSeek Harness is an open-source agent runtime that composes model adapters, tools, sessions, policy, sandboxing, and interfaces. The companion handbook is maintained separately at https://github.com/sandbaseai/deepseek-harness-handbook/ for multilingual, source-linked runbooks; this PR only adds the runtime itself.