### PR TITLE
docs: add DeepSeek Harness Handbook resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ timeline
 - [Workflow Framework](#workflow-framework-)
 - [AgentOps / Observability](#agentops--observability-)
 - [Protocol](#protocol-)
+- [Related Resources](#related-resources-)
 - [Roadmap](#roadmap-)
 - [Contributing](#contributing-)
 - [License](#license-)
@@ -144,6 +145,12 @@ Agent harnesses are end-user or developer-facing products that package model acc
 
 
 `Yes*` indicates a partially open-source, open-core, or otherwise limited open-source model.
+
+## Related Resources 🔎
+
+| Resource | What it provides |
+| --- | --- |
+| [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) | Source-backed runtime guides, multilingual troubleshooting, and a 31-resource Agent-first map for DeepSeek Harness operators. |
 
 ## Agent Framework 🧠
 


### PR DESCRIPTION
Add the independent DeepSeek Harness Handbook to Related Resources. It provides source-backed runtime guides, multilingual troubleshooting, and a 52-resource Agent-first map that complements this broader agent-harness index.

Current handbook snapshot: 173 canonical guides, 202 localized documents, and 79 GitHub stars. Latest release: https://github.com/sandbaseai/deepseek-harness-handbook/releases/tag/v0.5.383

The handbook is an independent reference, not an official DeepSeek AI project; its resource entries are discovery leads with explicit install, audit, and rollback boundaries.