### PR TITLE
docs: add SandBase Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Agent harnesses are end-user or developer-facing products that package model acc
 | [Hermes](https://github.com/nousresearch/hermes-agent) | 2026-02 | Nous Research | Yes |
 | [Warp](https://github.com/warpdotdev/warp) | 2026-04 | Warp | Yes |
 | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | 2026-05 | esengine | Yes |
+| [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) | 2026-08 | SandBase AI | Yes |
 
 
 `Yes*` indicates a partially open-source, open-core, or otherwise limited open-source model.


### PR DESCRIPTION
## Summary
- add SandBase Harness to the Agent Harness timeline
- link the official repository and identify SandBase AI as the developer

## Validation
- `git diff --check` passed
- project is Apache-2.0 and open source

Project: https://github.com/sandbaseai/sandbase-harness