### PR TITLE
Add Reef to Agent Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Agent harnesses are end-user or developer-facing products that package model acc
 | [Hermes](https://github.com/nousresearch/hermes-agent) | 2026-02 | Nous Research | Yes |
 | [Warp](https://github.com/warpdotdev/warp) | 2026-04 | Warp | Yes |
 | [Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | 2026-05 | esengine | Yes |
+| [Reef](https://github.com/Human-Agent-Society/reef) | 2026-08 | Human-Agent-Society | Yes |
 
 
 `Yes*` indicates a partially open-source, open-core, or otherwise limited open-source model.


### PR DESCRIPTION
Adds [Reef](https://github.com/Human-Agent-Society/reef) to the `Agent Harness 🚀` table, in release order after Reasonix.

> **Disclosure:** I am a maintainer of Reef.

## What it is

Apache-2.0, released 2026-08, by Human-Agent-Society. It serves agent requests behind an OpenAI- and Anthropic-compatible endpoint, records every interaction with a receipt, matches later score/feedback reports back to those receipts, and turns eligible records into a candidate update to either model weights or a harness tree of rules, skills, prompts, configuration and extensions. The harness recipe evaluates current versus candidate on configured tasks and publishes only when the candidate wins, keeping versioned rollback-capable history while the endpoint stays live.

You install and use the harness the way you install a coding agent:

```
curl -fsS -H "Authorization: Bearer $REEF_TOKEN" \
  'http://localhost:8900/reef/harness/install?adapter=pi' | bash
reef-pi -p "fix the bug"
```

The `pi` adapter targets [Pi Agent Core](https://github.com/badlogic/pi-mono), which you already list under Agent Framework.

## On placement — you may want to file it differently

I put it in Agent Harness because it is developer-facing and packages model access plus an execution loop into something you install and run. But I want to flag honestly that it is **not** an end-user product the way Cursor, Aider or OpenClaw are — it is the serving and update layer *underneath* a harness, and what it actually ships is a harness that keeps changing.

That makes it closest to the category your own timeline names in section 5: **Harness-as-a-Service**. If you'd rather (a) move it to Agent Framework, (b) start a HaaS / infrastructure section — I'd be glad to draft one, and Reef would not be the only candidate for it — or (c) decide it doesn't fit the list's shape, any of those is a reasonable call and I'll follow your lead.

## Accuracy note

Reef publishes no benchmark results and no reproducible evaluation of its own improvement claims. The table row asserts nothing beyond name, date, org and license, which is why I have not added a description; if you want the optional `Notes` column from the contributing template filled in, tell me the tone you want and I'll keep it purely mechanical.